### PR TITLE
Fix notification filter notifications not opening

### DIFF
--- a/notification_filter/notification_filter_domain/src/main/java/ly/com/tahaben/notification_filter_domain/use_cases/OpenNotification.kt
+++ b/notification_filter/notification_filter_domain/src/main/java/ly/com/tahaben/notification_filter_domain/use_cases/OpenNotification.kt
@@ -1,7 +1,10 @@
 package ly.com.tahaben.notification_filter_domain.use_cases
 
+import android.app.ActivityOptions
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.widget.Toast
 import ly.com.tahaben.core.R
 import ly.com.tahaben.notification_filter_domain.util.ServiceUtil
@@ -15,23 +18,42 @@ class OpenNotification(
         val pendingIntent = serviceUtil.getNotificationIntent(notificationKey)
         Timber.d("notification click $notificationKey")
         if (pendingIntent != null) {
-            pendingIntent.send()
-            Timber.d("notification click send")
-        } else {
-            Timber.d("notification click package $packageName")
-            val pm = context.packageManager
-            val intent = pm.getLaunchIntentForPackage(packageName)
-            if (intent != null) {
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                context.startActivity(intent)
-            } else {
-                Toast.makeText(
-                    context,
-                    context.getString(R.string.package_not_found_error),
-                    Toast.LENGTH_LONG
-                )
-                    .show()
+            val options = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                ActivityOptions.makeBasic()
+                    .setPendingIntentBackgroundActivityStartMode(
+                        // replaced by MODE_BACKGROUND_ACTIVITY_START_ALLOW_ALWAYS in API 36,
+                        // but this is the only constant that exists on API 34-35
+                        @Suppress("DEPRECATION")
+                        ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED
+                    )
+                    .toBundle()
+            } else null
+            try {
+                pendingIntent.send(context, 0, null, null, null, null, options)
+                Timber.d("notification click send")
+            } catch (e: PendingIntent.CanceledException) {
+                Timber.d(e, "pending intent was cancelled by creator app")
+                openApp(packageName)
             }
+        } else {
+            openApp(packageName)
+        }
+    }
+
+    private fun openApp(packageName: String) {
+        Timber.d("notification click package $packageName")
+        val pm = context.packageManager
+        val intent = pm.getLaunchIntentForPackage(packageName)
+        if (intent != null) {
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+        } else {
+            Toast.makeText(
+                context,
+                context.getString(R.string.package_not_found_error),
+                Toast.LENGTH_LONG
+            )
+                .show()
         }
     }
 }


### PR DESCRIPTION
Since android 14 the sender of pending intents must opt in to sharing its foregound privileges by passing an ActivityOptions bundle. Without the opt in the intent is dispatched but the resulting activity is silently aborted by ActivityTaskManager, this pull request adds the necessary bundle options for the pending intent fixing the 'no action on notification click' issue #83 